### PR TITLE
User can only unlike his own liked objects

### DIFF
--- a/src/Traits/CanLike.php
+++ b/src/Traits/CanLike.php
@@ -43,6 +43,7 @@ trait CanLike
         $relation = $object->likes()
             ->where('likable_id', $object->getKey())
             ->where('likable_type', $object->getMorphClass())
+            ->where(config('like.user_foreign_key'), $this->getKey())
             ->first();
 
         if ($relation) {


### PR DESCRIPTION
Previously users could 'unlike' other users likes, which isn't expected behavior. Added a condition in the unlike function that prevents this. 