### PR TITLE
Added return values for the like methods.

### DIFF
--- a/src/Traits/CanLike.php
+++ b/src/Traits/CanLike.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Overtrue\LaravelLike\Events\Liked;
 use Overtrue\LaravelLike\Events\Unliked;
+use Overtrue\LaravelLike\Like;
 
 /**
  * Trait CanBeLiked.
@@ -22,6 +23,7 @@ trait CanLike
 {
     /**
      * @param \Illuminate\Database\Eloquent\Model $object
+     * @return Like|null
      */
     public function like(Model $object)
     {
@@ -29,14 +31,19 @@ trait CanLike
             $like = app(config('like.like_model'));
             $like->{config('like.user_foreign_key')} = $this->getKey();
 
-            $object->likes()->save($like);
+            $like = $object->likes()->save($like);
 
             Event::dispatch(new Liked($this, $object));
+
+            return $like;
         }
+
+        return null;
     }
 
     /**
      * @param \Illuminate\Database\Eloquent\Model $object
+     * @return null
      */
     public function unlike(Model $object)
     {
@@ -50,14 +57,17 @@ trait CanLike
             $relation->delete();
             Event::dispatch(new Unliked($this, $object));
         }
+
+        return null;
     }
 
     /**
      * @param \Illuminate\Database\Eloquent\Model $object
+     * @return Like|null
      */
     public function toggleLike(Model $object)
     {
-        $this->hasLiked($object) ? $this->unlike($object) : $this->like($object);
+        return $this->hasLiked($object) ? $this->unlike($object) : $this->like($object);
     }
 
     /**

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -13,13 +13,14 @@ namespace Tests;
 use Illuminate\Support\Facades\Event;
 use Overtrue\LaravelLike\Events\Liked;
 use Overtrue\LaravelLike\Events\Unliked;
+use Overtrue\LaravelLike\Like;
 
 /**
  * Class FeatureTest.
  */
 class FeatureTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -28,12 +29,12 @@ class FeatureTest extends TestCase
         config(['auth.providers.users.model' => User::class]);
     }
 
-    public function testBasicFeatures()
+    public function test_basic_features()
     {
         $user = User::create(['name' => 'overtrue']);
         $post = Post::create(['title' => 'Hello world!']);
 
-        $user->like($post);
+        $this->assertInstanceOf(Like::class, $user->like($post));
 
         Event::assertDispatched(Liked::class, function ($event) use ($user, $post) {
             return $event->target instanceof Post && $event->user instanceof User && $event->user->id === $user->id && $event->target->id === $post->id;
@@ -42,7 +43,7 @@ class FeatureTest extends TestCase
         $this->assertTrue($user->hasLiked($post));
         $this->assertTrue($post->isLikedBy($user));
 
-        $user->unlike($post);
+        $this->assertNull($user->unlike($post));
 
         Event::assertDispatched(Unliked::class, function ($event) use ($user, $post) {
             return $event->target instanceof Post && $event->user instanceof User && $event->user->id === $user->id && $event->target->id === $post->id;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,7 +45,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * run package database migrations.
      */
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->loadMigrationsFrom(__DIR__.'/migrations');


### PR DESCRIPTION
Useful for example in an API like this:

    public function toggle(Request $request, $type, $id)
    {
        $model = $this->getModel($type, $id);
        $like = Auth::user()->toggleLike($model);

        return response()->json([
            'like' => $like,
        ]);
    }