### PR TITLE
Added explicit nullable type to attachLikeStatus parameter

### DIFF
--- a/src/Traits/Liker.php
+++ b/src/Traits/Liker.php
@@ -100,7 +100,7 @@ trait Liker
         );
     }
 
-    public function attachLikeStatus(&$likeables, callable $resolver = null)
+    public function attachLikeStatus(&$likeables, ?callable $resolver = null)
     {
         $likes = $this->likes()->get()->keyBy(function ($item) {
             return \sprintf('%s:%s', $item->likeable_type, $item->likeable_id);


### PR DESCRIPTION
This fixes the implicitly typed nullable parameter in [PHP8.4](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)