### PR TITLE
feat: prepare v6.0.0 for Laravel 13 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php_version: [8.2, 8.3, 8.4, 8.5]
+        php_version: [8.3, 8.4, 8.5]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Package: **overtrue/laravel-like**
 Like / favorite-style interactions for Eloquent models.
 
 ## Compatibility Targets
-- Laravel: **^9|^10|^11|^12|^13**
-- PHP: follow Laravel requirements (Laravel 13 requires PHP 8.3+)
+- Laravel: **^13**
+- PHP: **^8.3**
 
 ## Local Development
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Installing
 
+> Version 6.x requires **PHP 8.3+** and **Laravel 13+**.
+
 ```shell
 composer require overtrue/laravel-like -vvv
 ```

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.3",
+        "laravel/framework": "^13.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,9 +23,9 @@
         }
     },
     "require-dev": {
-        "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^11|^12",
-        "orchestra/testbench": "^10.0|^11.0",
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^12.0",
+        "orchestra/testbench": "^11.0",
         "friendsofphp/php-cs-fixer": "^3.0.0",
         "laravel/pint": "^1.2"
     },

--- a/config/like.php
+++ b/config/like.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\User;
+use Overtrue\LaravelLike\Like;
+
 return [
     /**
      * Use uuid as primary key.
@@ -19,10 +22,10 @@ return [
     /*
      * Model name for like record.
      */
-    'like_model' => \Overtrue\LaravelLike\Like::class,
+    'like_model' => Like::class,
 
     /*
      * Model name for liker.
      */
-    'user_model' => class_exists(\App\Models\User::class) ? \App\Models\User::class : null,
+    'user_model' => class_exists(User::class) ? User::class : null,
 ];

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class Event
 {
     /**
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var Model
      */
     public $like;
 

--- a/src/Like.php
+++ b/src/Like.php
@@ -4,6 +4,8 @@ namespace Overtrue\LaravelLike;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Str;
 use Overtrue\LaravelLike\Events\Liked;
 use Overtrue\LaravelLike\Events\Unliked;
@@ -38,13 +40,13 @@ class Like extends Model
         });
     }
 
-    public function likeable(): \Illuminate\Database\Eloquent\Relations\MorphTo
+    public function likeable(): MorphTo
     {
         return $this->morphTo();
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function user()
     {
@@ -54,7 +56,7 @@ class Like extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo
      */
     public function liker()
     {
@@ -62,7 +64,7 @@ class Like extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeWithType(Builder $query, string $type)
     {

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -4,6 +4,7 @@ namespace Overtrue\LaravelLike\Traits;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 trait Likeable
 {
@@ -23,7 +24,7 @@ trait Likeable
     /**
      * Return followers.
      */
-    public function likers(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function likers(): BelongsToMany
     {
         return $this->belongsToMany(
             config('like.user_model') ?? config('auth.providers.users.model'),

--- a/src/Traits/Liker.php
+++ b/src/Traits/Liker.php
@@ -3,6 +3,7 @@
 namespace Overtrue\LaravelLike\Traits;
 
 use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -88,7 +89,7 @@ trait Liker
     /**
      * Get Query Builder for likes
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function getLikedItems(string $model)
     {

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -3,9 +3,11 @@
 namespace Tests;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Overtrue\LaravelLike\Events\Liked;
 use Overtrue\LaravelLike\Events\Unliked;
+use Overtrue\LaravelLike\Like;
 
 class FeatureTest extends TestCase
 {
@@ -257,7 +259,7 @@ class FeatureTest extends TestCase
 
         // Act & Assert - First toggle should like the post
         $like = $user->toggleLike($post);
-        $this->assertInstanceOf(\Overtrue\LaravelLike\Like::class, $like, 'Toggle should return Like instance when liking');
+        $this->assertInstanceOf(Like::class, $like, 'Toggle should return Like instance when liking');
         $this->assertTrue($user->hasLiked($post), 'User should have liked the post after toggle');
 
         // Act & Assert - Second toggle should unlike the post
@@ -319,8 +321,8 @@ class FeatureTest extends TestCase
         $user->like($book);
 
         // Act & Assert - Scope should filter by type
-        $postLikes = \Overtrue\LaravelLike\Like::withType(Post::class)->get();
-        $bookLikes = \Overtrue\LaravelLike\Like::withType(Book::class)->get();
+        $postLikes = Like::withType(Post::class)->get();
+        $bookLikes = Like::withType(Book::class)->get();
 
         $this->assertCount(1, $postLikes, 'Should have 1 post like');
         $this->assertCount(1, $bookLikes, 'Should have 1 book like');
@@ -385,7 +387,7 @@ class FeatureTest extends TestCase
 
         // Assert - Liked event should contain correct data
         Event::assertDispatched(Liked::class, function ($event) use ($user, $post) {
-            return $event->like instanceof \Overtrue\LaravelLike\Like
+            return $event->like instanceof Like
                 && $event->like->user_id === $user->id
                 && $event->like->likeable_id === $post->id
                 && $event->like->likeable_type === $post->getMorphClass();
@@ -396,7 +398,7 @@ class FeatureTest extends TestCase
 
         // Assert - Unliked event should contain correct data
         Event::assertDispatched(Unliked::class, function ($event) use ($user, $post) {
-            return $event->like instanceof \Overtrue\LaravelLike\Like
+            return $event->like instanceof Like
                 && $event->like->user_id === $user->id
                 && $event->like->likeable_id === $post->id
                 && $event->like->likeable_type === $post->getMorphClass();
@@ -413,7 +415,7 @@ class FeatureTest extends TestCase
     public function test_like_model_uses_custom_model_class()
     {
         // Arrange - Create custom like model
-        $customLikeModel = new class extends \Overtrue\LaravelLike\Like
+        $customLikeModel = new class extends Like
         {
             protected $table = 'likes';
         };
@@ -430,7 +432,7 @@ class FeatureTest extends TestCase
         $this->assertInstanceOf(get_class($customLikeModel), $like, 'Should use custom like model class');
     }
 
-    protected function getQueryLog(\Closure $callback): \Illuminate\Support\Collection
+    protected function getQueryLog(\Closure $callback): Collection
     {
         $sqls = \collect([]);
         \DB::listen(function ($query) use ($sqls) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Application;
 use Overtrue\LaravelLike\LikeServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
@@ -9,7 +10,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Load package service provider.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     protected function getPackageProviders($app)
@@ -20,7 +21,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function getEnvironmentSetUp($app)
     {


### PR DESCRIPTION
- drop support for Laravel 12 and below
- require PHP 8.3+
- require `laravel/framework ^13.0`
- require `orchestra/testbench ^11.0`
- align dev dependencies with the new major baseline
- fix existing Pint style issues so checks pass cleanly
- document the new 6.x install baseline in README

Validation:
- `composer test` ✅
- `composer check-style` ✅

This PR prepares the next major release: **v6.0.0**, with Laravel 13 as the only supported framework version.